### PR TITLE
Add R2DBC Persistence Support for Events and Snapshots  

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,13 @@ module github.com/abyssal-kraken/abyssalkraken
 
 go 1.23
 
-require github.com/google/uuid v1.6.0
+require (
+	github.com/google/uuid v1.6.0
+	gorm.io/gorm v1.25.12
+)
+
+require (
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
+	golang.org/x/text v0.14.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,10 @@
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
+github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
+github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+gorm.io/gorm v1.25.12 h1:I0u8i2hWQItBq1WfE0o2+WuL9+8L21K9e2HHSTE/0f8=
+gorm.io/gorm v1.25.12/go.mod h1:xh7N7RHfYlNc5EmcI/El95gXusucDrQnHXe0+CgWcLQ=

--- a/pkg/abyssalkraken/persistence/r2dbc/r2dbc_event_persistence.go
+++ b/pkg/abyssalkraken/persistence/r2dbc/r2dbc_event_persistence.go
@@ -1,0 +1,72 @@
+package r2dbc
+
+import (
+	"context"
+	"fmt"
+	"github.com/abyssal-kraken/abyssalkraken/pkg/abyssalkraken/persistence"
+	"gorm.io/gorm"
+)
+
+type R2dbcEventPersistence struct {
+	db        *gorm.DB
+	tableName string
+}
+
+func NewR2dbcEventPersistence(db *gorm.DB, tableName string) *R2dbcEventPersistence {
+	return &R2dbcEventPersistence{
+		db:        db,
+		tableName: tableName,
+	}
+}
+
+func (r *R2dbcEventPersistence) Append(ctx context.Context, name string, data []byte, expectedVersion int64, newVersion int64) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var actualVersion int64
+
+		err := tx.Raw(
+			fmt.Sprintf("SELECT COALESCE(MAX(version), %d) FROM %s WHERE name = ?", 0, r.tableName),
+			name,
+		).Scan(&actualVersion).Error
+		if err != nil {
+			return fmt.Errorf("failed to determine actual version: %w", err)
+		}
+
+		if actualVersion != expectedVersion {
+			return &persistence.PersistenceConcurrencyError{
+				Name:            name,
+				ActualVersion:   actualVersion,
+				ExpectedVersion: expectedVersion,
+			}
+		}
+
+		err = tx.Exec(
+			fmt.Sprintf("INSERT INTO %s (name, version, data) VALUES (?, ?, ?)", r.tableName),
+			name, newVersion, data,
+		).Error
+		if err != nil {
+			return fmt.Errorf("failed to append data: %w", err)
+		}
+
+		return nil
+	})
+}
+
+func (r *R2dbcEventPersistence) ReadRecords(ctx context.Context, name string, afterVersion *int64) ([]persistence.BinaryData, error) {
+	query := fmt.Sprintf("SELECT name, version, data FROM %s WHERE name = ?", r.tableName)
+	var params []interface{}
+
+	params = append(params, name)
+
+	if afterVersion != nil {
+		query += " AND version > ?"
+		params = append(params, *afterVersion)
+	}
+
+	var results []persistence.BinaryData
+	err := r.db.WithContext(ctx).Raw(query, params...).Scan(&results).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to read records: %w", err)
+	}
+
+	return results, nil
+}

--- a/pkg/abyssalkraken/persistence/r2dbc/r2dbc_snapshot_persistence.go
+++ b/pkg/abyssalkraken/persistence/r2dbc/r2dbc_snapshot_persistence.go
@@ -1,0 +1,80 @@
+package r2dbc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/abyssal-kraken/abyssalkraken/pkg/abyssalkraken/persistence"
+	"gorm.io/gorm"
+)
+
+type R2dbcSnapshotPersistence struct {
+	db        *gorm.DB
+	tableName string
+}
+
+func NewR2dbcSnapshotPersistence(db *gorm.DB, tableName string) *R2dbcSnapshotPersistence {
+	return &R2dbcSnapshotPersistence{
+		db:        db,
+		tableName: tableName,
+	}
+}
+
+func (r *R2dbcSnapshotPersistence) Upsert(ctx context.Context, name string, data []byte, expectedVersion int64, newVersion int64) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var actualVersion *int64
+
+		err := tx.Raw(
+			fmt.Sprintf("SELECT MAX(version) FROM %s WHERE name = ?", r.tableName),
+			name,
+		).Scan(&actualVersion).Error
+		if err != nil {
+			return fmt.Errorf("failed to determine actual version: %w", err)
+		}
+
+		if actualVersion == nil {
+			err = tx.Exec(
+				fmt.Sprintf("INSERT INTO %s (name, version, data) VALUES (?, ?, ?)", r.tableName),
+				name, newVersion, data,
+			).Error
+			if err != nil {
+				return fmt.Errorf("failed to insert snapshot: %w", err)
+			}
+		} else {
+			if *actualVersion != expectedVersion {
+				return &persistence.PersistenceConcurrencyError{
+					Name:            name,
+					ActualVersion:   *actualVersion,
+					ExpectedVersion: expectedVersion,
+				}
+			}
+
+			err = tx.Exec(
+				fmt.Sprintf("UPDATE %s SET data = ?, version = ? WHERE name = ?", r.tableName),
+				data, newVersion, name,
+			).Error
+			if err != nil {
+				return fmt.Errorf("failed to update snapshot: %w", err)
+			}
+		}
+
+		return nil
+	})
+}
+
+func (r *R2dbcSnapshotPersistence) ReadRecord(ctx context.Context, name string) (*persistence.BinaryData, error) {
+	var result persistence.BinaryData
+
+	err := r.db.WithContext(ctx).Raw(
+		fmt.Sprintf("SELECT name, version, data FROM %s WHERE name = ?", r.tableName),
+		name,
+	).Scan(&result).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read snapshot: %w", err)
+	}
+
+	return &result, nil
+}


### PR DESCRIPTION
# ✨ Add R2DBC Persistence Support for Events and Snapshots  

## Description  
This pull request introduces support for **R2DBC-based persistence** for managing events and snapshots in the project. The implementation includes:  

### R2dbcEventPersistence  
- Implements event persistence with transactional support for appending new events.  
- Ensures version consistency with optimistic concurrency checks.  
- Provides a method to read event records after a specific version.  

### R2dbcSnapshotPersistence  
- Implements snapshot persistence with methods to upsert (insert/update) snapshots.  
- Handles version-based optimistic concurrency.  
- Supports retrieving snapshots based on their name.  

## Key Changes  
- Added two new structures:
  - `R2dbcEventPersistence` for event storage.
  - `R2dbcSnapshotPersistence` for snapshot storage.  
- Leveraged **GORM** SQL generation and transaction management for database operations.  
- Added SQL queries to handle concurrency and data integrity using `MAX(version)` checks.  
- Updated `go.mod` to include necessary dependencies:
  - `gorm.io/gorm`
  - `github.com/jinzhu/inflection`
  - `golang.org/x/text`

## Highlights  
- Transactions (`gorm.DB.Transaction`) ensure atomic operations during inserts/updates.  
- Provides clean error handling, including custom concurrency exceptions.  
- Optimized with raw SQL queries for better performance with GORM.  

These changes lay the foundation for efficient, concurrent-safe, event-sourced application management. 🚀  